### PR TITLE
Update url tags for pepository and bugtracker

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,8 @@
 
   <maintainer email="k104009y@mail.kyutech.jp">Arita Yuta</maintainer>
   <license>MIT</license>
-  <!-- <url type="website">http://wiki.ros.org/third_robot_monitor</url> -->
+  <url type="repository">https://github.com/CIR-KIT/remote_monitor.git</url>
+  <url type="bugtracker">https://github.com/CIR-KIT/remote_monitor/issues</url>
 
   <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
 


### PR DESCRIPTION
https://github.com/CIR-KIT/waypoint_manager/pull/6 にて話した内容と同様の変更を適用しました。